### PR TITLE
Drop unused import Test from plover_build_utils, it's gone

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setuptools>=36.4.0
 
 from setuptools import setup
 
-from plover_build_utils.setup import BuildPy, BuildUi, Test
+from plover_build_utils.setup import BuildPy, BuildUi
 
 BuildPy.build_dependencies.append('build_ui')
 BuildUi.hooks = ['plover_build_utils.pyqt:fix_icons']


### PR DESCRIPTION
```
error: builder for '/nix/store/w6xkpra5xpizs7w6mcn773iljyx76ayq-python3.10-plover_dictionary_builder-0.1.0.drv' failed with exit code 1;
       last 10 log lines:
       > configuring
       > no configure script, doing nothing
       > building
       > Executing setuptoolsBuildPhase
       > Traceback (most recent call last):
       >   File "/build/plover_dictionary_builder-0.1.0/nix_run_setup", line 8, in <module>
       >     exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
       >   File "setup.py", line 10, in <module>
       >     from plover_build_utils.setup import BuildPy, BuildUi, Test
       > ImportError: cannot import name 'Test' from 'plover_build_utils.setup' (/nix/store/sh72966kj5jz3dlp7rjlmrmhpfsybkin-python3.10-plover-4.0.0.dev12/lib/python3.10/site-packages/plover_build_utils/setup.py)
       For full logs, run 'nix log /nix/store/w6xkpra5xpizs7w6mcn773iljyx76ayq-python3.10-plover_dictionary_builder-0.1.0.drv'.
```